### PR TITLE
Add support for NUnit3TestGeneratorProvider.

### DIFF
--- a/NCrunchAttributeGeneratorProvider.cs
+++ b/NCrunchAttributeGeneratorProvider.cs
@@ -21,6 +21,9 @@ namespace NCrunch.Generator.SpecflowPlugin
             switch (runtimeUnitTestProvider.ToUpper(CultureInfo.InvariantCulture))
             {
                 case "NUNIT":
+                    baseGeneratorProvider = new NUnit3TestGeneratorProvider(codeDomHelper);
+                    break;
+                case "NUNIT.2":
                     baseGeneratorProvider = new NUnitTestGeneratorProvider(codeDomHelper);
                     break;
                 case "MSTEST":


### PR DESCRIPTION
Previously SpecFlow.NCrunch invoked use of the older NUnitTestGeneratorProvider under the newer NUnit 3.  This older provider does not set a Reason parameter when creating NUnit Ignore attrbiutes, however a non-empty Ignore Reason is now required under NUnit 3.  So the effect was that use of SpecFlow.NCrunch was changing SpecFlow behavior such that generated tests would not build for NUnit 3.  SpecFlow normally uses the newer NUnit3TestGeneratorProvider which addresses the Ignore Reason issue.  This small patch aligns SpecFlow.NCrunch to do the same. 